### PR TITLE
Fix: Matter example game Replication & Formatting

### DIFF
--- a/example/matter/src/client/systems/receiveReplication.lua
+++ b/example/matter/src/client/systems/receiveReplication.lua
@@ -1,6 +1,8 @@
 local ReplicatedStorage = game:GetService("ReplicatedStorage")
 local Components = require(ReplicatedStorage.Shared.components)
-local identifiers = require(ReplicatedStorage.Shared.identifiers)
+local Identifiers = require(ReplicatedStorage.Shared.identifiers)
+
+local entityIdMap = {}
 
 local function receiveReplication(world, state, _ui, net)
 	local function debugPrint(...)
@@ -9,9 +11,7 @@ local function receiveReplication(world, state, _ui, net)
 		end
 	end
 
-	local entityIdMap = {}
-
-	for _, entities in net:query(identifiers.Replication) do
+	for _, entities in net:query(Identifiers.Replication) do
 		for serverEntityId, componentMap in entities do
 			local clientEntityId = entityIdMap[serverEntityId]
 

--- a/example/matter/src/server/systems/replication.lua
+++ b/example/matter/src/server/systems/replication.lua
@@ -1,8 +1,8 @@
 local Players = game:GetService("Players")
 local ReplicatedStorage = game:GetService("ReplicatedStorage")
 local Components = require(ReplicatedStorage.Shared.components)
+local Identifiers = require(ReplicatedStorage.Shared.identifiers)
 local useEvent = require(ReplicatedStorage.Packages.Matter).useEvent
-local identifiers = require(ReplicatedStorage.Shared.identifiers)
 
 local REPLICATED_COMPONENTS = {
 	"Roomba",
@@ -35,7 +35,7 @@ local function replication(world, _state, _ui, net)
 		end
 
 		print("Sending initial payload to", player)
-		net:send(player, identifiers.Replication, payload)
+		net:send(player, Identifiers.Replication, payload)
 	end
 
 	local changes = {}
@@ -56,7 +56,7 @@ local function replication(world, _state, _ui, net)
 	end
 
 	if next(changes) then
-		net:send(Players:GetPlayers(), identifiers.Replication, changes)
+		net:send(Players:GetPlayers(), Identifiers.Replication, changes)
 	end
 end
 


### PR DESCRIPTION
The current way that replication was done made a copy of the entity every time a change was fired
The formatting was a little odd, so I fixed that too