### PR TITLE
Fix #8 & #9

### DIFF
--- a/docs/setup/matter.mdx
+++ b/docs/setup/matter.mdx
@@ -118,9 +118,9 @@ Being initially made for the Matter ECS, Net provides a simple function for sche
 Firstly, create a ``routes.ts`` ModuleScript in ReplicatedStorage to strictly declare your Routes.
 
 ```ts title="routes.ts"
-import { Route } from "@rbxts/yetanothernet";
+import { Route, Configuration } from "@rbxts/yetanothernet";
 
-const defaultConfiguration = {
+const defaultConfiguration: Configuration = {
   Channel: "Reliable",
   Event: "default",
 }

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -1,10 +1,5 @@
 type Recipient = "NET_SERVER" | Player | [Player]
 
-type Configuration = {
-    Channel: "Reliable" | "Unreliable" | undefined,
-    Event: string | undefined,
-}
-
 /**
  * Allows for modification of queued packets before they're sent.
  */
@@ -39,6 +34,11 @@ type QueryResult<T extends Array<any>> = Query<T> & {
 
 declare namespace Net {
     const server: "NET_SERVER";
+
+    type Configuration = {
+        Channel: "Reliable" | "Unreliable" | undefined,
+        Event: string | undefined,
+    }
 
     class Route<T extends Array<any>> {
         public constructor(configuration: Configuration | null);
@@ -96,8 +96,7 @@ declare namespace Net {
      * @param loop - A Matter Loop
      * @param routes - An array of your routes
      */
-    function start<T extends Array<any>>(loop: any, routes: Array<Route<T>>): void
-
+    function start(loop: any, routes: {[index: string]: Route<any>}): void
     /**
      * This function allows you to run Net scheduling code on your own events.
      * 
@@ -111,7 +110,7 @@ declare namespace Net {
      * ```
      * @param routes - An array of your routes
      */
-    function createHook<T extends Array<any>>(routes: Array<Route<T>>): () => void
+    function createHook(routes: {[index: string]: Route<any>}): () => void
 }
 
 export = Net


### PR DESCRIPTION
Fixes issue #8 by exposing the `Configuration` type to the `Net` namespace and changes docs accordingly. One thing to note about this is that by importing this type, Roblox's [Configuration](https://create.roblox.com/docs/reference/engine/classes/Configuration) type is obscured, this could be fixed by renaming the type to something like `RouteConfiguration`

Fixes issue #9 as suggested by turning the `routes` argument of `Net.start` and `Net.createHook` into an object, and changing the `Routes` type to any